### PR TITLE
doc: removing section preceding replicate instructions

### DIFF
--- a/docs/pre-work/README.md
+++ b/docs/pre-work/README.md
@@ -47,12 +47,6 @@ git clone https://github.com/ibm-granite-community/granite-timeseries-workshop.g
 cd granite-timeseries-workshop
 ```
 
-### Serving the Granite AI Models
-
-<!-- Which timeseries labs need to be served by an AI model runtime? -->
-
-[Lab 1: Energy Demand Forecasting Basic Inference](../lab-1/README.md), [Lab 2: Energy Demand Forecasting Preprocessing and Performance Evaluation](../lab-2/README.md), [Lab 3: Energy Demand Forecasting Few-shot Fine-tuning](../lab-3/README.md), [Lab 4: Bike Sharing Forecasting Zero-shot, Fine-tuning, and Performance Evaluation](../lab-4/README.md), [Lab 5: Getting Started with Watson X AI SDK](../lab-5/README.md), and [Lab 6: Retail Forecasting using M5 Sales Data Few-shot, Fine-tuning, Evaluation, and Visualization](../lab-6/README.md), require Granite models to be served by an AI model runtime so that the models can be invoked or called.
-
 ### Install Jupyter
 
 !!! note "Use a virtual environment"
@@ -89,14 +83,9 @@ cd granite-timeseries-workshop
 Running the lab notebooks remotely using [Google Colab](https://colab.research.google.com) requires the following steps:
 
 - [Colab Prerequisites](#colab-prerequisites)
-- [Serving the Granite AI Models for Colab](#serving-the-granite-ai-models-for-colab)
 
 ### Colab Prerequisites
 
 - [Google Colab](https://colab.research.google.com) requires a Google account that you're logged into
 
-### Serving the Granite AI Models for Colab
 
-<!-- Which timeseries labs need to be served by an AI model runtime? -->
-
-[Lab 1: Energy Demand Forecasting Basic Inference](../lab-1/README.md), [Lab 2: Energy Demand Forecasting Preprocessing and Performance Evaluation](../lab-2/README.md), [Lab 3: Energy Demand Forecasting Few-shot Fine-tuning](../lab-3/README.md), [Lab 4: Bike Sharing Forecasting Zero-shot, Fine-tuning, and Performance Evaluation](../lab-4/README.md), [Lab 5: Getting Started with Watson X AI SDK](../lab-5/README.md), and [Lab 6: Retail Forecasting using M5 Sales Data Few-shot, Fine-tuning, Evaluation, and Visualization](../lab-6/README.md), require Granite models to be served by an AI model runtime so that the models can be invoked or called.


### PR DESCRIPTION
When the replicate instructions were removed in the previous PR, the preceding section that provides a bit of context should also have been removed.